### PR TITLE
使用server.css, client不再重复使用style-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,10 +144,25 @@ const bbq = (config) => {
     };
     const hashPrefix = config.cssLoaderHashPrefix || '';
     const styleQuery = `modules&localIdentName=[name]__[local]___[hash:base64:5]&hashPrefix=${hashPrefix}&importLoaders=1`;
+
+    const serverCssRe = /\.server\.css$/;
+    const serverCssLoader = {
+      test: serverCssRe,
+      include: `${config.basedir}/src/`,
+      loaders: target === 'web' ?
+         [
+          `${cssLoaderName}/locals?${styleQuery}`,
+          'postcss-loader',
+         ] : [
+        `${cssLoaderName}/locals?${styleQuery}&cssText`,
+        'postcss-loader',
+        ]
+    };
+
     const style = {
       test: /\.css$/,
       include: `${config.basedir}/src/`,
-      exclude: filepath => globalCssRe.test(path.basename(filepath)),
+      exclude: filepath => globalCssRe.test(path.basename(filepath)) || serverCssRe.test(path.basename(filepath)),
       use: target === 'web' ? [
         styleLoaderName,
         `${cssLoaderName}?${styleQuery}`,


### PR DESCRIPTION
使用server端react渲染首屏时，可以使用定义在组件上的静态方法来将依赖样式打入到style标签中

因为同构react的缘故，组件在client端构成时，不需要再使用style-loader， 会造成冗余部分

不建议使用global.css来形成css.bundle（阻塞首屏渲染)？

是否还有更优化的解决方案？